### PR TITLE
Temporary fix for PDF URL

### DIFF
--- a/src/menu_downloader.py
+++ b/src/menu_downloader.py
@@ -1,12 +1,14 @@
 import logging
-
 import requests
 
 
 def construct_menu_url(date):
     year = date.year
-    timestamp = date.strftime('%y%m%d-%a')
-    return f'https://uci.nus.edu.sg/ohs/wp-content/uploads/sites/3/{year}/01/{timestamp}-Daily-Menu.pdf'
+    # TODO: Temporary hack for the PDF URL
+    date_diff = (date.date() - datetime.date(2020,8,3))
+    week_num = 1 + date_diff.days // 7
+    day_of_week = date.strftime('%a')
+    return f'https://uci.nus.edu.sg/ohs/wp-content/uploads/sites/3/{year}/08/Wk-{week_num}-{day_of_week}.pdf'
 
 
 def send_request_for_menu_pdf(url):


### PR DESCRIPTION
The bot is currently broken because OHS changed the PDF naming scheme, this should fix it for the next month at least

I think a better solution would be to use something like https://github.com/ahobsonsayers/html-table-parser-python3 or https://srome.github.io/Parsing-HTML-Tables-in-Python-with-BeautifulSoup-and-pandas/ to directly retrieve the URL from https://uci.nus.edu.sg/ohs/current-residents/students/daily-menu-2/.  However, I'm currently unable to work on that because I'm being blocked by Incapsula. (I'm not sure if the bot is blocked too, maybe it isn't because it's running on NUS servers?)